### PR TITLE
Add rollup-plugin-istanbul to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,24 @@
 [![npm](https://img.shields.io/npm/dw/playwright-test-coverage)](https://npmtrends.com/playwright-test-coverage)
 [![Awesome](https://awesome.re/badge.svg)](https://github.com/mxschmitt/awesome-playwright)
 
-A [Playwright](https://playwright.dev) extension that collects code coverage from running end-to-end tests. Assumes that code has been instrumented with [babel-plugin-istanbul](https://github.com/istanbuljs/babel-plugin-istanbul) during the build process.
+A [Playwright](https://playwright.dev) extension that collects code coverage from running end-to-end tests. Assumes that code has been instrumented with [istanbul-lib-instrument](https://www.npmjs.com/package/istanbul-lib-instrument) during the build process, for example, with [babel-plugin-istanbul](https://github.com/istanbuljs/babel-plugin-istanbul) or [rollup-plugin-istanbul](https://github.com/artberri/rollup-plugin-istanbul).
 
 ## Prerequisites
 
 - Playwright test framework
-- `babel-plugin-istanbul` plugin
-- `nyc` for running tests
+- A process to instrument your JavaScript code (if you are using babel, `babel-plugin-istanbul` or if you are using `rollup`, `rollup-plugin-istanbul`)
+- `nyc` for running tests or for manually generating the reports
+
+#### If you are using babel
 
 ```bash
 npm i -D @playwright/test babel-plugin-istanbul nyc
+```
+
+#### If you are using rollup
+
+```bash
+npm i -D @playwright/test rollup-plugin-istanbul nyc
 ```
 
 ## Installation
@@ -40,9 +48,9 @@ test("basic test", async ({ page }) => {
 });
 ```
 
-Then, instrument your front end source code for coverage using the `babel-plugin-istanbul` plugin.
+Then, instrument your front end source code for coverage using the `babel-plugin-istanbul` or the `rollup-plugin-istanbul`.
 
-Finally, run your server via `nyc` to capture code coverage. For more details see [istanbul/nyc](https://github.com/istanbuljs/nyc).
+Finally, run your server via `nyc` to capture code coverage or manually run `nyc` with the `report` option. For more details see [istanbul/nyc](https://github.com/istanbuljs/nyc).
 
 ### Options
 


### PR DESCRIPTION
I saw a mention to this package [in this Playwright issue](https://github.com/microsoft/playwright/issues/7030) but as I saw in the README that it was intended to be used with `babel-plugin-istanbul` and I was not using it, I skipped it and used a copy of the [baseFixtures.ts](https://github.com/mxschmitt/playwright-test-coverage/blob/1acb1d99459e28cca81630aa079677296b4df7b7/e2e/baseFixtures.ts) file directly. Later I noticed that this package [is indeed the same code contained in that file](https://github.com/mxschmitt/playwright-test-coverage/issues/1#issuecomment-913851822) with some extra features for env variables, so I replaced the baseFixtures.ts file with it.

This pull request adds information to the README of the repo that the code should be instrumented with `istanbul-lib-instrument` but to do that one could use plugins that use this library to perform such a task, like `babel-plugin-istanbul` or `rollup-plugin-istanbul`, so other users that are using the later to build their bundles could know that this package could be used to generate the coverage of the code with `Playwright`.

[In one of the packages that I maintain](https://github.com/elchininet/keep-texts-in-tabs), I use [rollup](https://rollupjs.org/) to build the final bundle, and to instrument the code I use [rollup-plugin-istanbul](https://github.com/artberri/rollup-plugin-istanbul). As I am using [Playwright with Docker](https://playwright.dev/docs/docker), I cannot use `nyc` to start the server, or what `nyc` will cpature will be the usage of the `playwright.config.ts` file. I needed to use [the report option of nyc](https://github.com/elchininet/keep-texts-in-tabs/blob/d0408ba76e1482d5528d059a3f1fd5f435a2a44e/package.json#L22) once the coverage files were generated in the `.nyc_output` folder. I also I addded a mention to this in the README to avoid giving the idea that running a server with `nyc` is the only option to generate the final coverage.