### PR TITLE
Add a closure of the callback function for page.evaluate

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,9 @@ const test = baseTest.extend({
     });
     await use(context);
     for (const page of context.pages()) {
-      await page.evaluate(() =>
-        window.collectIstanbulCoverage(JSON.stringify(window.__coverage__)),
-      );
+      await page.evaluate(() => {
+        window.collectIstanbulCoverage(JSON.stringify(window.__coverage__));
+      });
     }
   },
 });


### PR DESCRIPTION
Without this closure, this may occur with browser fixture created from extending test

Error: page.evaluate: TypeError: callbacks.set is not a function

        at <anonymous>:24:64
        at new Promise (<anonymous>)
        at globalThis.<computed> (<anonymous>:24:21)
        at eval (eval at evaluate (:234:30), <anonymous>:2:16)
        at UtilityScript.evaluate (<anonymous>:236:17)
        at UtilityScript.<anonymous> (<anonymous>:1:44)